### PR TITLE
Test: Write Comprehensive Tests For the DAOController Component

### DIFF
--- a/src/components/dao_controller.cairo
+++ b/src/components/dao_controller.cairo
@@ -247,7 +247,7 @@ pub mod VotingComponent {
 
     #[generate_trait]
     pub impl VoteInternalImpl<
-        TContractState, +HasComponent<ComponentState<TContractState>>,
+        TContractState, +HasComponent<TContractState>,
     > of VoteTrait<TContractState> {
         fn _initialize(
             ref self: ComponentState<TContractState>,

--- a/src/components/dao_controller.cairo
+++ b/src/components/dao_controller.cairo
@@ -106,7 +106,7 @@ pub mod VotingComponent {
             // this until the permission control component is added to the codebase
 
             if poll.up_votes >= threshold {
-                let outcome = poll.resolve();
+                let outcome = poll.resolve(threshold);
                 self.emit(PollResolved { id: poll_id, outcome, timestamp })
             }
             self.has_voted.entry((caller, poll_id)).write(true);
@@ -140,7 +140,7 @@ pub mod VotingComponent {
             let max_no_of_possible_approvals = max_possible_of_voters - poll.down_votes;
 
             if max_no_of_possible_approvals < threshold {
-                let outcome = poll.resolve();
+                let outcome = poll.resolve(threshold);
                 self.emit(PollResolved { id: poll_id, outcome, timestamp })
             }
 

--- a/src/lib.cairo
+++ b/src/lib.cairo
@@ -32,8 +32,10 @@ pub mod structs {
 
 #[cfg(test)]
 pub mod tests {
+    pub mod test_dao_controller;
     pub mod test_member_manager;
     pub mod mocks {
+        pub mod mock_dao_controller;
         pub mod mock_member_manager;
     }
 }

--- a/src/structs/dao_controller.cairo
+++ b/src/structs/dao_controller.cairo
@@ -69,8 +69,8 @@ pub struct CHANGEORGANIZATIONTYPE {
 
 #[generate_trait]
 pub impl PollImpl of PollTrait {
-    fn resolve(ref self: Poll) -> bool {
-        assert(self.up_votes + self.down_votes >= DEFAULT_THRESHOLD, 'COULD NOT RESOLVE');
+    fn resolve(ref self: Poll, threshold: u256) -> bool {
+        assert(self.up_votes + self.down_votes >= threshold, 'COULD NOT RESOLVE');
         let mut status = false;
         if self.up_votes > self.down_votes {
             status = true;

--- a/src/structs/dao_controller.cairo
+++ b/src/structs/dao_controller.cairo
@@ -140,10 +140,10 @@ pub type Power = u16;
 
 #[derive(Drop, Serde, Copy, Default)]
 pub struct VotingConfig {
-    private: bool,
-    threshold: u256,
-    weighted: bool,
-    weighted_with: ContractAddress // weight with this token, else, use rank.
+    pub private: bool,
+    pub threshold: u256,
+    pub weighted: bool,
+    pub weighted_with: ContractAddress // weight with this token, else, use rank.
 }
 
 // For the default

--- a/src/tests/mocks/mock_dao_controller.cairo
+++ b/src/tests/mocks/mock_dao_controller.cairo
@@ -1,0 +1,51 @@
+use littlefinger::interfaces::dao_controller::IVote as IMockVote;
+use starknet::ContractAddress;
+
+#[starknet::contract]
+pub mod MockDaoController {
+    use littlefinger::components::dao_controller::VotingComponent;
+    use littlefinger::components::member_manager::MemberManagerComponent;
+    use littlefinger::structs::dao_controller::{
+        Poll, PollCreated, PollReason, PollResolved, PollStatus, PollStopped, PollTrait,
+        ThresholdChanged, Voted, VotingConfig, VotingConfigNode,
+    };
+    use littlefinger::structs::member_structs::{MemberRoleIntoU16, MemberTrait};
+    use starknet::ContractAddress;
+
+    component!(path: VotingComponent, storage: dao_controller, event: DaoControllerEvent);
+    component!(path: MemberManagerComponent, storage: member_manager, event: MemberManagerEvent);
+
+    #[abi(embed_v0)]
+    pub impl VotingImpl = VotingComponent::VotingImpl<ContractState>;
+
+    #[abi(embed_v0)]
+    pub impl MemberManagerImpl =
+        MemberManagerComponent::MemberManager<ContractState>;
+
+
+    pub impl InternalImpl = VotingComponent::VoteInternalImpl<ContractState>;
+
+    #[storage]
+    pub struct Storage {
+        #[substorage(v0)]
+        pub dao_controller: VotingComponent::Storage,
+        #[substorage(v0)]
+        pub member_manager: MemberManagerComponent::Storage,
+    }
+
+    #[event]
+    #[derive(Drop, starknet::Event)]
+    enum Event {
+        #[flat]
+        DaoControllerEvent: VotingComponent::Event,
+        #[flat]
+        MemberManagerEvent: MemberManagerComponent::Event,
+    }
+
+    #[constructor]
+    fn constructor(
+        ref self: ContractState, admin: ContractAddress, config: VotingConfig, threshold: u256,
+    ) {
+        self.dao_controller._initialize(admin, config, threshold);
+    }
+}

--- a/src/tests/mocks/mock_dao_controller.cairo
+++ b/src/tests/mocks/mock_dao_controller.cairo
@@ -24,6 +24,7 @@ pub mod MockDaoController {
 
 
     pub impl InternalImpl = VotingComponent::VoteInternalImpl<ContractState>;
+    pub impl MemberInternalImpl = MemberManagerComponent::InternalImpl<ContractState>;
 
     #[storage]
     pub struct Storage {
@@ -44,8 +45,29 @@ pub mod MockDaoController {
 
     #[constructor]
     fn constructor(
-        ref self: ContractState, admin: ContractAddress, config: VotingConfig, threshold: u256,
+        ref self: ContractState,
+        admin: ContractAddress,
+        config: VotingConfig,
+        threshold: u256,
+        first_admin_fname: felt252,
+        first_admin_lname: felt252,
+        first_admin_alias: felt252,
+        member1: ContractAddress,
+        member2: ContractAddress,
+        member3: ContractAddress,
     ) {
         self.dao_controller._initialize(admin, config, threshold);
+        self
+            .member_manager
+            ._initialize(first_admin_fname, first_admin_lname, first_admin_alias, admin);
+        self
+            .member_manager
+            .add_member('Member1'.into(), 'LastName1'.into(), 'Alias1'.into(), 5, member1);
+        self
+            .member_manager
+            .add_member('Member2'.into(), 'LastName2'.into(), 'Alias2'.into(), 0, member2);
+        self
+            .member_manager
+            .add_member('Member3'.into(), 'LastName3'.into(), 'Alias3'.into(), 5, member3);
     }
 }

--- a/src/tests/mocks/mock_member_manager.cairo
+++ b/src/tests/mocks/mock_member_manager.cairo
@@ -1,10 +1,3 @@
-use littlefinger::interfaces::imember_manager::IMemberManager as IMockMemberManager;
-use littlefinger::structs::member_structs::{
-    InviteStatus, Member, MemberConfig, MemberConfigNode, MemberDetails, MemberEnum, MemberEvent,
-    MemberInvite, MemberInvited, MemberNode, MemberResponse, MemberRole, MemberStatus, MemberTrait,
-};
-use starknet::ContractAddress;
-
 #[starknet::contract]
 pub mod MockMemberManager {
     use littlefinger::components::member_manager::MemberManagerComponent;

--- a/src/tests/test_dao_controller.cairo
+++ b/src/tests/test_dao_controller.cairo
@@ -3,10 +3,12 @@ use littlefinger::interfaces::imember_manager::{
     IMemberManagerDispatcher, IMemberManagerDispatcherTrait,
 };
 use littlefinger::structs::dao_controller::{
-    Poll, PollCreated, PollReason, PollResolved, PollStatus, PollStopped, PollTrait,
-    ThresholdChanged, Voted, VotingConfig, VotingConfigNode, ADDMEMBER,
+    ADDMEMBER, Poll, PollCreated, PollReason, PollResolved, PollStatus, PollStopped, PollTrait,
+    ThresholdChanged, Voted, VotingConfig, VotingConfigNode,
 };
-use littlefinger::structs::member_structs::{MemberInvite, MemberRoleIntoU16, MemberRole, InviteStatus};
+use littlefinger::structs::member_structs::{
+    InviteStatus, MemberInvite, MemberRole, MemberRoleIntoU16,
+};
 use littlefinger::tests::mocks::mock_dao_controller::MockDaoController;
 use snforge_std::{
     ContractClassTrait, DeclareResultTrait, declare, start_cheat_block_timestamp,
@@ -85,7 +87,6 @@ fn test_poll_creation_success() {
         base_pay: 5_u256,
         invite_status: InviteStatus::PENDING,
         expiry: 2000,
-
     };
     let add_member_data = ADDMEMBER { member: member_invite_instance, member_address: member1() };
 
@@ -119,16 +120,15 @@ fn test_poll_creation_fail_verification() {
         base_pay: 5_u256,
         invite_status: InviteStatus::PENDING,
         expiry: 2000,
-
     };
     let add_member_data = ADDMEMBER { member: member_invite_instance, member_address: member4() };
 
     start_cheat_caller_address(voting.contract_address, unauthorized_caller());
     start_cheat_block_timestamp(voting.contract_address, 1000);
-    
+
     let member1_id = 2;
     let reason = PollReason::ADDMEMBER(add_member_data);
-    
+
     voting.create_poll(member1_id, reason);
 }
 

--- a/src/tests/test_dao_controller.cairo
+++ b/src/tests/test_dao_controller.cairo
@@ -250,7 +250,7 @@ fn test_poll_rejection_success() {
 
 #[test]
 #[should_panic(expected: 'CALLER HAS VOTED')]
-fn test_poll_rejection_fail_double_vote(){
+fn test_poll_rejection_fail_double_vote() {
     let voting = deploy_mock_voting_contract();
     start_cheat_caller_address(voting.contract_address, member1());
     start_cheat_block_timestamp(voting.contract_address, 1000);
@@ -412,10 +412,7 @@ fn test_update_voting_config_does_not_panic() {
     start_cheat_caller_address(voting.contract_address, member1());
 
     let config = VotingConfig {
-        private: false,
-        threshold: 123,
-        weighted: false,
-        weighted_with: member1(),
+        private: false, threshold: 123, weighted: false, weighted_with: member1(),
     };
     voting.update_voting_config(config);
 

--- a/src/tests/test_dao_controller.cairo
+++ b/src/tests/test_dao_controller.cairo
@@ -74,6 +74,21 @@ fn unauthorized_caller() -> ContractAddress {
     contract_address_const::<'unauthorized'>()
 }
 
+fn multiple_approve(voting: IVoteDispatcher, poll_id: u256) {
+    start_cheat_caller_address(voting.contract_address, member1());
+    let mut member_id: u256 = 2;
+    voting.approve(poll_id, member_id);
+    stop_cheat_caller_address(voting.contract_address);
+    start_cheat_caller_address(voting.contract_address, member2());
+    member_id = 3;
+    voting.approve(poll_id, member_id);
+    stop_cheat_caller_address(voting.contract_address);
+    start_cheat_caller_address(voting.contract_address, member3());
+    member_id = 4;
+    voting.approve(poll_id, member_id);
+    stop_cheat_caller_address(voting.contract_address);
+}
+
 
 #[test]
 fn test_poll_creation_success() {
@@ -181,6 +196,32 @@ fn test_poll_approval_fail_double_vote() {
 }
 
 #[test]
+#[should_panic(expected: 'POLL NOT ACTIVE')]
+fn test_poll_approval_fail_inactive_poll() {
+    let voting = deploy_mock_voting_contract();
+    start_cheat_caller_address(voting.contract_address, member1());
+    start_cheat_block_timestamp(voting.contract_address, 1000);
+    let member_invite_instance = MemberInvite {
+        address: member4(),
+        role: MemberRole::EMPLOYEE(5),
+        base_pay: 5_u256,
+        invite_status: InviteStatus::PENDING,
+        expiry: 2000,
+    };
+    let add_member_data = ADDMEMBER { member: member_invite_instance, member_address: member4() };
+    let member_id = 2;
+    let reason = PollReason::ADDMEMBER(add_member_data);
+    let poll_id = voting.create_poll(member_id, reason);
+    stop_cheat_block_timestamp(voting.contract_address);
+    multiple_approve(voting, poll_id);
+    let mut poll = voting.get_poll(poll_id);
+    poll.resolve(2);
+    start_cheat_caller_address(voting.contract_address, admin());
+    voting.approve(poll_id, 1);
+    stop_cheat_caller_address(voting.contract_address);
+}
+
+#[test]
 fn test_poll_rejection_success() {
     let voting = deploy_mock_voting_contract();
     start_cheat_caller_address(voting.contract_address, member1());
@@ -205,4 +246,199 @@ fn test_poll_rejection_success() {
 
     stop_cheat_caller_address(voting.contract_address);
     stop_cheat_block_timestamp(voting.contract_address);
+}
+
+#[test]
+#[should_panic(expected: 'CALLER HAS VOTED')]
+fn test_poll_rejection_fail_double_vote(){
+    let voting = deploy_mock_voting_contract();
+    start_cheat_caller_address(voting.contract_address, member1());
+    start_cheat_block_timestamp(voting.contract_address, 1000);
+    let member_invite_instance = MemberInvite {
+        address: member4(),
+        role: MemberRole::EMPLOYEE(5),
+        base_pay: 5_u256,
+        invite_status: InviteStatus::PENDING,
+        expiry: 2000,
+    };
+    let add_member_data = ADDMEMBER { member: member_invite_instance, member_address: member4() };
+    let member1_id = 2;
+    let reason = PollReason::ADDMEMBER(add_member_data);
+    let poll_id = voting.create_poll(member1_id, reason);
+    voting.reject(poll_id, member1_id);
+    voting.reject(poll_id, member1_id);
+}
+
+#[test]
+#[should_panic(expected: 'POLL NOT ACTIVE')]
+fn test_poll_reject_fail_inactive_poll() {
+    let voting = deploy_mock_voting_contract();
+    start_cheat_caller_address(voting.contract_address, member1());
+    start_cheat_block_timestamp(voting.contract_address, 1000);
+    let member_invite_instance = MemberInvite {
+        address: member4(),
+        role: MemberRole::EMPLOYEE(5),
+        base_pay: 5_u256,
+        invite_status: InviteStatus::PENDING,
+        expiry: 2000,
+    };
+    let add_member_data = ADDMEMBER { member: member_invite_instance, member_address: member4() };
+    let member_id = 2;
+    let reason = PollReason::ADDMEMBER(add_member_data);
+    let poll_id = voting.create_poll(member_id, reason);
+    stop_cheat_block_timestamp(voting.contract_address);
+    multiple_approve(voting, poll_id);
+    let mut poll = voting.get_poll(poll_id);
+    poll.resolve(2);
+    start_cheat_caller_address(voting.contract_address, admin());
+    voting.reject(poll_id, 1);
+    stop_cheat_caller_address(voting.contract_address);
+}
+
+#[test]
+fn test_set_threshold_success() {
+    let voting = deploy_mock_voting_contract();
+
+    start_cheat_caller_address(voting.contract_address, member1());
+    start_cheat_block_timestamp(voting.contract_address, 1000);
+
+    let prev_threshold = voting.get_threshold();
+
+    let member1_id = 2;
+    let new_threshold: u256 = 42;
+
+    voting.set_threshold(new_threshold, member1_id);
+
+    let updated_threshold = voting.get_threshold();
+    assert(updated_threshold == new_threshold, 'Threshold should be updated');
+    assert(updated_threshold != prev_threshold, 'Threshold should change');
+
+    stop_cheat_caller_address(voting.contract_address);
+    stop_cheat_block_timestamp(voting.contract_address);
+}
+
+
+#[test]
+#[should_panic(expected: 'VERIFICATION FAILED')]
+fn test_set_threshold_fail_verification() {
+    let voting = deploy_mock_voting_contract();
+
+    start_cheat_caller_address(voting.contract_address, unauthorized_caller());
+    start_cheat_block_timestamp(voting.contract_address, 1000);
+
+    let member_id = 2;
+    let new_threshold: u256 = 77;
+
+    voting.set_threshold(new_threshold, member_id);
+
+    stop_cheat_caller_address(voting.contract_address);
+    stop_cheat_block_timestamp(voting.contract_address);
+}
+
+#[test]
+fn test_get_all_polls_returns_all_created_polls() {
+    let voting = deploy_mock_voting_contract();
+    start_cheat_caller_address(voting.contract_address, member1());
+    start_cheat_block_timestamp(voting.contract_address, 1000);
+
+    let member_invite_instance = MemberInvite {
+        address: member1(),
+        role: MemberRole::EMPLOYEE(5),
+        base_pay: 5_u256,
+        invite_status: InviteStatus::PENDING,
+        expiry: 2000,
+    };
+    let add_member_data = ADDMEMBER { member: member_invite_instance, member_address: member1() };
+    let reason = PollReason::ADDMEMBER(add_member_data);
+
+    let poll_id_1 = voting.create_poll(2, reason);
+    let poll_id_2 = voting.create_poll(2, reason);
+
+    let polls = voting.get_all_polls();
+    println!("Poll len: {}", polls.len());
+    assert(*polls.at(0).poll_id == poll_id_1, 'First poll id mismatch');
+    assert(*polls.at(1).poll_id == poll_id_2, 'Second poll id mismatch');
+
+    stop_cheat_caller_address(voting.contract_address);
+    stop_cheat_block_timestamp(voting.contract_address);
+}
+
+#[test]
+fn test_get_threshold_returns_current_threshold() {
+    let voting = deploy_mock_voting_contract();
+    start_cheat_caller_address(voting.contract_address, member1());
+
+    let initial_threshold = voting.get_threshold();
+    assert(initial_threshold == 2, 'Initial threshold incorrect');
+
+    let new_threshold: u256 = 55;
+    voting.set_threshold(new_threshold, 2);
+    let updated_threshold = voting.get_threshold();
+    assert(updated_threshold == new_threshold, 'Threshold should be updated');
+
+    stop_cheat_caller_address(voting.contract_address);
+}
+
+#[test]
+fn test_get_poll_returns_correct_poll() {
+    let voting = deploy_mock_voting_contract();
+    start_cheat_caller_address(voting.contract_address, member1());
+    start_cheat_block_timestamp(voting.contract_address, 1000);
+
+    let member_invite_instance = MemberInvite {
+        address: member1(),
+        role: MemberRole::EMPLOYEE(5),
+        base_pay: 5_u256,
+        invite_status: InviteStatus::PENDING,
+        expiry: 2000,
+    };
+    let add_member_data = ADDMEMBER { member: member_invite_instance, member_address: member1() };
+    let reason = PollReason::ADDMEMBER(add_member_data);
+
+    let poll_id = voting.create_poll(2, reason);
+    let poll = voting.get_poll(poll_id);
+
+    assert(poll.poll_id == poll_id, 'Poll id mismatch');
+    assert(poll.proposer == 2, 'Proposer id mismatch');
+    assert(poll.reason == reason, 'Poll reason mismatch');
+
+    stop_cheat_caller_address(voting.contract_address);
+    stop_cheat_block_timestamp(voting.contract_address);
+}
+
+#[test]
+fn test_update_voting_config_does_not_panic() {
+    let voting = deploy_mock_voting_contract();
+    start_cheat_caller_address(voting.contract_address, member1());
+
+    let config = VotingConfig {
+        private: false,
+        threshold: 123,
+        weighted: false,
+        weighted_with: member1(),
+    };
+    voting.update_voting_config(config);
+
+    stop_cheat_caller_address(voting.contract_address);
+}
+
+#[test]
+fn test_get_eligible_voters_returns_expected_ids() {
+    let voting = deploy_mock_voting_contract();
+    let eligible_voters = voting.get_eligible_voters();
+    assert(eligible_voters.len() > 0, 'Incorrect eligible voters');
+}
+
+#[test]
+fn test_get_eligible_pollers_returns_expected_ids() {
+    let voting = deploy_mock_voting_contract();
+    let eligible_pollers = voting.get_eligible_pollers();
+    assert(eligible_pollers.len() > 0, 'Incorrect eligible pollers');
+}
+
+#[test]
+fn test_get_eligible_executors_returns_expected_ids() {
+    let voting = deploy_mock_voting_contract();
+    let eligible_executors = voting.get_eligible_executors();
+    assert(eligible_executors.len() > 0, 'incorrect eligible executors');
 }

--- a/src/tests/test_dao_controller.cairo
+++ b/src/tests/test_dao_controller.cairo
@@ -1,0 +1,49 @@
+use littlefinger::interfaces::dao_controller::{IVoteDispatcher, IVoteDispatcherTrait};
+use littlefinger::structs::dao_controller::{
+    Poll, PollCreated, PollReason, PollResolved, PollStatus, PollStopped, PollTrait,
+    ThresholdChanged, Voted, VotingConfig, VotingConfigNode,
+};
+use littlefinger::tests::mocks::mock_dao_controller::MockDaoController;
+use snforge_std::{
+    ContractClassTrait, DeclareResultTrait, declare, start_cheat_block_timestamp,
+    start_cheat_caller_address, stop_cheat_block_timestamp, stop_cheat_caller_address,
+};
+use starknet::{ContractAddress, contract_address_const};
+
+fn deploy_mock_voting_contract() -> IVoteDispatcher {
+    let admin: ContractAddress = admin();
+    let threshold: u256 = 2.into(); // Minimum votes required to resolve poll
+    let config: VotingConfig = VotingConfig {
+        private: true, threshold: 1000, weighted: true, weighted_with: dummy_address(),
+    };
+    let contract_class = declare("MockDAOController").unwrap().contract_class();
+    let mut calldata = array![admin.into()];
+    Serde::serialize(@config, ref calldata);
+    threshold.serialize(ref calldata);
+    let (contract_address, _) = contract_class.deploy(@calldata.into()).unwrap();
+    IVoteDispatcher { contract_address }
+}
+
+fn admin() -> ContractAddress {
+    contract_address_const::<'admin'>()
+}
+
+fn dummy_address() -> ContractAddress {
+    contract_address_const::<'dummy'>()
+}
+
+fn member1() -> ContractAddress {
+    contract_address_const::<'member1'>()
+}
+
+fn member2() -> ContractAddress {
+    contract_address_const::<'member2'>()
+}
+
+fn member3() -> ContractAddress {
+    contract_address_const::<'member3'>()
+}
+
+fn unauthorized_caller() -> ContractAddress {
+    contract_address_const::<'unauthorized'>()
+}

--- a/src/tests/test_dao_controller.cairo
+++ b/src/tests/test_dao_controller.cairo
@@ -1,8 +1,12 @@
 use littlefinger::interfaces::dao_controller::{IVoteDispatcher, IVoteDispatcherTrait};
+use littlefinger::interfaces::imember_manager::{
+    IMemberManagerDispatcher, IMemberManagerDispatcherTrait,
+};
 use littlefinger::structs::dao_controller::{
     Poll, PollCreated, PollReason, PollResolved, PollStatus, PollStopped, PollTrait,
-    ThresholdChanged, Voted, VotingConfig, VotingConfigNode,
+    ThresholdChanged, Voted, VotingConfig, VotingConfigNode, ADDMEMBER,
 };
+use littlefinger::structs::member_structs::{MemberInvite, MemberRoleIntoU16, MemberRole, InviteStatus};
 use littlefinger::tests::mocks::mock_dao_controller::MockDaoController;
 use snforge_std::{
     ContractClassTrait, DeclareResultTrait, declare, start_cheat_block_timestamp,
@@ -14,18 +18,34 @@ fn deploy_mock_voting_contract() -> IVoteDispatcher {
     let admin: ContractAddress = admin();
     let threshold: u256 = 2.into(); // Minimum votes required to resolve poll
     let config: VotingConfig = VotingConfig {
-        private: true, threshold: 1000, weighted: true, weighted_with: dummy_address(),
+        private: true, threshold: 1000, weighted: true, weighted_with: admin.into(),
     };
-    let contract_class = declare("MockDAOController").unwrap().contract_class();
+    let contract_class = declare("MockDaoController").unwrap().contract_class();
     let mut calldata = array![admin.into()];
     Serde::serialize(@config, ref calldata);
     threshold.serialize(ref calldata);
+    let first_admin_fname: felt252 = 'Admin';
+    let first_admin_lname: felt252 = 'User';
+    let first_admin_alias: felt252 = 'adminuser';
+    first_admin_fname.serialize(ref calldata);
+    first_admin_lname.serialize(ref calldata);
+    first_admin_alias.serialize(ref calldata);
+    let member1: ContractAddress = member1();
+    let member2: ContractAddress = member2();
+    let member3: ContractAddress = member3();
+    member1.serialize(ref calldata);
+    member2.serialize(ref calldata);
+    member3.serialize(ref calldata);
     let (contract_address, _) = contract_class.deploy(@calldata.into()).unwrap();
     IVoteDispatcher { contract_address }
 }
 
 fn admin() -> ContractAddress {
     contract_address_const::<'admin'>()
+}
+
+fn admin_details() -> (felt252, felt252, felt252) {
+    ('Admin', 'User', 'adminuser')
 }
 
 fn dummy_address() -> ContractAddress {
@@ -44,6 +64,145 @@ fn member3() -> ContractAddress {
     contract_address_const::<'member3'>()
 }
 
+fn member4() -> ContractAddress {
+    contract_address_const::<'member4'>()
+}
+
 fn unauthorized_caller() -> ContractAddress {
     contract_address_const::<'unauthorized'>()
+}
+
+
+#[test]
+fn test_poll_creation_success() {
+    let voting = deploy_mock_voting_contract();
+
+    start_cheat_caller_address(voting.contract_address, member1());
+    start_cheat_block_timestamp(voting.contract_address, 1000);
+    let member_invite_instance = MemberInvite {
+        address: member1(),
+        role: MemberRole::EMPLOYEE(5),
+        base_pay: 5_u256,
+        invite_status: InviteStatus::PENDING,
+        expiry: 2000,
+
+    };
+    let add_member_data = ADDMEMBER { member: member_invite_instance, member_address: member1() };
+
+    let member1_id = 2;
+
+    let reason = PollReason::ADDMEMBER(add_member_data);
+    let poll_id = voting.create_poll(member1_id, reason);
+
+    assert(poll_id == 0, 'Poll ID should be 0');
+    let poll = voting.get_poll(poll_id);
+    assert(poll.proposer == member1_id, 'Proposer ID should match');
+    assert(poll.poll_id == poll_id, 'Poll ID should match');
+    assert(poll.reason == reason, 'Poll reason should match');
+    assert(poll.up_votes == 0, 'Up votes should be 0');
+    assert(poll.down_votes == 0, 'Down votes should be 0');
+    assert(poll.status == PollStatus::ACTIVE, 'Poll status should be ACTIVE');
+    assert(poll.created_at == 1000, 'Poll timestamp should match');
+
+    stop_cheat_caller_address(voting.contract_address);
+    stop_cheat_block_timestamp(voting.contract_address);
+}
+
+#[test]
+#[should_panic(expected: 'VERIFICATION FAILED')]
+fn test_poll_creation_fail_verification() {
+    let voting = deploy_mock_voting_contract();
+
+    let member_invite_instance = MemberInvite {
+        address: member4(),
+        role: MemberRole::None,
+        base_pay: 5_u256,
+        invite_status: InviteStatus::PENDING,
+        expiry: 2000,
+
+    };
+    let add_member_data = ADDMEMBER { member: member_invite_instance, member_address: member4() };
+
+    start_cheat_caller_address(voting.contract_address, unauthorized_caller());
+    start_cheat_block_timestamp(voting.contract_address, 1000);
+    
+    let member1_id = 2;
+    let reason = PollReason::ADDMEMBER(add_member_data);
+    
+    voting.create_poll(member1_id, reason);
+}
+
+#[test]
+fn test_poll_approval_success() {
+    let voting = deploy_mock_voting_contract();
+    start_cheat_caller_address(voting.contract_address, member1());
+    start_cheat_block_timestamp(voting.contract_address, 1000);
+    let member_invite_instance = MemberInvite {
+        address: member4(),
+        role: MemberRole::EMPLOYEE(5),
+        base_pay: 5_u256,
+        invite_status: InviteStatus::PENDING,
+        expiry: 2000,
+    };
+    let add_member_data = ADDMEMBER { member: member_invite_instance, member_address: member4() };
+    let member1_id = 2;
+    let reason = PollReason::ADDMEMBER(add_member_data);
+    let poll_id = voting.create_poll(member1_id, reason);
+    voting.approve(poll_id, member1_id);
+    let poll = voting.get_poll(poll_id);
+    assert(poll.up_votes == 1, 'Up votes should be 1');
+    assert(poll.down_votes == 0, 'Down votes should be 0');
+    assert(poll.status == PollStatus::ACTIVE, 'Poll status not ACTIVE');
+    assert(poll.created_at == 1000, 'Poll timestamp should match');
+
+    stop_cheat_caller_address(voting.contract_address);
+    stop_cheat_block_timestamp(voting.contract_address);
+}
+
+#[test]
+#[should_panic(expected: 'CALLER HAS VOTED')]
+fn test_poll_approval_fail_double_vote() {
+    let voting = deploy_mock_voting_contract();
+    start_cheat_caller_address(voting.contract_address, member1());
+    start_cheat_block_timestamp(voting.contract_address, 1000);
+    let member_invite_instance = MemberInvite {
+        address: member4(),
+        role: MemberRole::EMPLOYEE(5),
+        base_pay: 5_u256,
+        invite_status: InviteStatus::PENDING,
+        expiry: 2000,
+    };
+    let add_member_data = ADDMEMBER { member: member_invite_instance, member_address: member4() };
+    let member1_id = 2;
+    let reason = PollReason::ADDMEMBER(add_member_data);
+    let poll_id = voting.create_poll(member1_id, reason);
+    voting.approve(poll_id, member1_id);
+    voting.approve(poll_id, member1_id);
+}
+
+#[test]
+fn test_poll_rejection_success() {
+    let voting = deploy_mock_voting_contract();
+    start_cheat_caller_address(voting.contract_address, member1());
+    start_cheat_block_timestamp(voting.contract_address, 1000);
+    let member_invite_instance = MemberInvite {
+        address: member4(),
+        role: MemberRole::EMPLOYEE(5),
+        base_pay: 5_u256,
+        invite_status: InviteStatus::PENDING,
+        expiry: 2000,
+    };
+    let add_member_data = ADDMEMBER { member: member_invite_instance, member_address: member4() };
+    let member1_id = 2;
+    let reason = PollReason::ADDMEMBER(add_member_data);
+    let poll_id = voting.create_poll(member1_id, reason);
+    voting.reject(poll_id, member1_id);
+    let poll = voting.get_poll(poll_id);
+    assert(poll.up_votes == 0, 'Up votes should be 0');
+    assert(poll.down_votes == 1, 'Down votes should be 1');
+    assert(poll.status == PollStatus::ACTIVE, 'Poll status not ACTIVE');
+    assert(poll.created_at == 1000, 'Poll timestamp should match');
+
+    stop_cheat_caller_address(voting.contract_address);
+    stop_cheat_block_timestamp(voting.contract_address);
 }


### PR DESCRIPTION
closes #44 
This PR adds the `MockDaoController` contract and unit tests to verify the behavior of `VotingConfig` within the `littlefinger` architecture.

## Key Changes

- Implements a mock DAO contract with:
  - `VotingComponent` (via `VotingImpl`, `VoteInternalImpl`)
  - `MemberManagerComponent` (via `MemberManagerImpl`)
- Adds storage for both voting and member management.